### PR TITLE
Allow nginx ≥1.23.2 ssl_session_tickets

### DIFF
--- a/src/js/configs.js
+++ b/src/js/configs.js
@@ -104,7 +104,7 @@ module.exports = {
   nginx: {
     checked: true,
     highlighter: 'nginx',
-    latestVersion: '1.25.3',
+    latestVersion: '1.25.4',
     name: 'nginx',
     tls13: '1.13.0',
   },

--- a/src/js/configs.js
+++ b/src/js/configs.js
@@ -104,7 +104,7 @@ module.exports = {
   nginx: {
     checked: true,
     highlighter: 'nginx',
-    latestVersion: '1.25.5',
+    latestVersion: '1.26.0',
     name: 'nginx',
     tls13: '1.13.0',
   },

--- a/src/js/configs.js
+++ b/src/js/configs.js
@@ -104,7 +104,7 @@ module.exports = {
   nginx: {
     checked: true,
     highlighter: 'nginx',
-    latestVersion: '1.17.7',
+    latestVersion: '1.25.3',
     name: 'nginx',
     tls13: '1.13.0',
   },

--- a/src/js/configs.js
+++ b/src/js/configs.js
@@ -109,7 +109,7 @@ module.exports = {
     tls13: '1.13.0',
   },
   openssl: {
-    latestVersion: '1.1.1k',
+    latestVersion: '1.1.1w',
     tls13: '1.1.1',
   },
   oraclehttp: {

--- a/src/js/configs.js
+++ b/src/js/configs.js
@@ -104,7 +104,7 @@ module.exports = {
   nginx: {
     checked: true,
     highlighter: 'nginx',
-    latestVersion: '1.25.4',
+    latestVersion: '1.25.5',
     name: 'nginx',
     tls13: '1.13.0',
   },

--- a/src/templates/partials/nginx.hbs
+++ b/src/templates/partials/nginx.hbs
@@ -24,8 +24,8 @@ server {
     ssl_certificate_key /path/to/private_key;
     ssl_session_timeout 1d;
     ssl_session_cache shared:MozSSL:10m;  # about 40000 sessions
-{{#unless (minver "1.23.2" form.serverVersion)}}{{!-- safe now: https://github.com/mozilla/server-side-tls/issues/284 --}}
-{{#if (minver "1.0.2l" form.opensslVersion)}}{{!-- openssl bug: https://github.com/mozilla/server-side-tls/issues/134 --}}
+{{#unless (minver "1.23.2" form.serverVersion)~}}  {{!-- safe now: https://github.com/mozilla/server-side-tls/issues/284 --}}
+{{#if (minver "1.0.2l" form.opensslVersion)~}}  {{!-- openssl bug: https://github.com/mozilla/server-side-tls/issues/134 --}}
   {{#if (minver "1.5.9" form.serverVersion)}}
     ssl_session_tickets off;
   {{/if}}

--- a/src/templates/partials/nginx.hbs
+++ b/src/templates/partials/nginx.hbs
@@ -24,11 +24,13 @@ server {
     ssl_certificate_key /path/to/private_key;
     ssl_session_timeout 1d;
     ssl_session_cache shared:MozSSL:10m;  # about 40000 sessions
+{{#unless (minver "1.23.2" form.serverVersion)}}  {{!-- safe now: https://github.com/mozilla/server-side-tls/issues/284 --}}
 {{#if (minver "1.0.2l" form.opensslVersion)}}  {{!-- openssl bug: https://github.com/mozilla/server-side-tls/issues/134 --}}
   {{#if (minver "1.5.9" form.serverVersion)}}
     ssl_session_tickets off;
   {{/if}}
 {{/if}}
+{{/unless}}
 
 {{#if output.usesDhe}}
     # {{output.dhCommand}} > /path/to/dhparam

--- a/src/templates/partials/nginx.hbs
+++ b/src/templates/partials/nginx.hbs
@@ -24,7 +24,7 @@ server {
     ssl_certificate_key /path/to/private_key;
     ssl_session_timeout 1d;
     ssl_session_cache shared:MozSSL:10m;  # about 40000 sessions
-{{#if (minver "1.0.2l" form.opensslVersion)}}
+{{#if (minver "1.0.2l" form.opensslVersion)}}  {{!-- #143 buggy openssl --}}
   {{#if (minver "1.5.9" form.serverVersion)}}
     ssl_session_tickets off;
   {{/if}}

--- a/src/templates/partials/nginx.hbs
+++ b/src/templates/partials/nginx.hbs
@@ -24,8 +24,8 @@ server {
     ssl_certificate_key /path/to/private_key;
     ssl_session_timeout 1d;
     ssl_session_cache shared:MozSSL:10m;  # about 40000 sessions
-{{#unless (minver "1.23.2" form.serverVersion)}}  {{~!-- safe now: https://github.com/mozilla/server-side-tls/issues/284 --~}}
-{{#if (minver "1.0.2l" form.opensslVersion)}}  {{~!-- openssl bug: https://github.com/mozilla/server-side-tls/issues/134 --~}}
+{{#unless (minver "1.23.2" form.serverVersion)}}
+{{#if (minver "1.0.2l" form.opensslVersion)}}
   {{#if (minver "1.5.9" form.serverVersion)}}
     ssl_session_tickets off;
   {{/if}}

--- a/src/templates/partials/nginx.hbs
+++ b/src/templates/partials/nginx.hbs
@@ -24,8 +24,8 @@ server {
     ssl_certificate_key /path/to/private_key;
     ssl_session_timeout 1d;
     ssl_session_cache shared:MozSSL:10m;  # about 40000 sessions
-{{#unless (minver "1.23.2" form.serverVersion)}}  {{!-- safe now: https://github.com/mozilla/server-side-tls/issues/284 --}}
-{{#if (minver "1.0.2l" form.opensslVersion)}}  {{!-- openssl bug: https://github.com/mozilla/server-side-tls/issues/134 --}}
+{{#unless (minver "1.23.2" form.serverVersion)}}{{!-- safe now: https://github.com/mozilla/server-side-tls/issues/284 --}}
+{{#if (minver "1.0.2l" form.opensslVersion)}}{{!-- openssl bug: https://github.com/mozilla/server-side-tls/issues/134 --}}
   {{#if (minver "1.5.9" form.serverVersion)}}
     ssl_session_tickets off;
   {{/if}}

--- a/src/templates/partials/nginx.hbs
+++ b/src/templates/partials/nginx.hbs
@@ -24,7 +24,7 @@ server {
     ssl_certificate_key /path/to/private_key;
     ssl_session_timeout 1d;
     ssl_session_cache shared:MozSSL:10m;  # about 40000 sessions
-{{#if (minver "1.0.2l" form.opensslVersion)}}  {{!-- #143 buggy openssl --}}
+{{#if (minver "1.0.2l" form.opensslVersion)}}  {{!-- openssl bug: https://github.com/mozilla/server-side-tls/issues/134 --}}
   {{#if (minver "1.5.9" form.serverVersion)}}
     ssl_session_tickets off;
   {{/if}}

--- a/src/templates/partials/nginx.hbs
+++ b/src/templates/partials/nginx.hbs
@@ -24,8 +24,8 @@ server {
     ssl_certificate_key /path/to/private_key;
     ssl_session_timeout 1d;
     ssl_session_cache shared:MozSSL:10m;  # about 40000 sessions
-{{#unless (minver "1.23.2" form.serverVersion)~}}  {{!-- safe now: https://github.com/mozilla/server-side-tls/issues/284 --}}
-{{#if (minver "1.0.2l" form.opensslVersion)~}}  {{!-- openssl bug: https://github.com/mozilla/server-side-tls/issues/134 --}}
+{{#unless (minver "1.23.2" form.serverVersion)}}  {{~!-- safe now: https://github.com/mozilla/server-side-tls/issues/284 --~}}
+{{#if (minver "1.0.2l" form.opensslVersion)}}  {{~!-- openssl bug: https://github.com/mozilla/server-side-tls/issues/134 --~}}
   {{#if (minver "1.5.9" form.serverVersion)}}
     ssl_session_tickets off;
   {{/if}}


### PR DESCRIPTION
FYI: https://trac.nginx.org/nginx/milestone/nginx-1.23.2 (https://nginx.org/en/CHANGES-1.24)

- https://github.com/mozilla/server-side-tls/issues/284

refs:
- https://github.com/mozilla/server-side-tls/issues/135
- (commit log:) https://github.com/mozilla/server-side-tls/commit/168bcd7021f83474f77f894888a06d5870732cee
- (archived:) [wiki.mozilla.org/Security/Archive/Server_Side_TLS_4.0#TLS_tickets](https://wiki.mozilla.org/Security/Archive/Server_Side_TLS_4.0#TLS_tickets_.28RFC_5077.29)

OQ:
- https://github.com/mozilla/ssl-config-generator/issues/69
- https://github.com/mozilla/server-side-tls/issues/282