### PR TITLE
Fix Caddy TLS version support

### DIFF
--- a/src/js/configs.js
+++ b/src/js/configs.js
@@ -37,7 +37,7 @@ module.exports = {
   caddy: {
     cipherFormat: 'caddy',
     highlighter: 'nginx', // TODO: find better
-    latestVersion: '2.1.1',
+    latestVersion: '2.7.6',
     name: 'Caddy',
     supportsOcspStapling: false, // actually true; can't be disabled in Caddy
     tls13: '0.11.5',

--- a/src/templates/partials/caddy.hbs
+++ b/src/templates/partials/caddy.hbs
@@ -14,7 +14,7 @@ tls {
     protocols tls1.2 tls1.3
     ciphers {{{join output.ciphers " "}}}
     {{ else }}
-    protocols tls1.0 tls1.1 tls1.2 tls1.3
+    protocols tls1.0 tls1.1 tls1.2{{#if (includes "TLSv1.3" output.protocols)}} tls1.3{{/if}}
     # NOTE: Ciphers for old Caddy v1.x are based on recommendations v5.2 and not updated to accomodate newer changes.
     ciphers ECDHE-ECDSA-AES128-GCM-SHA256 ECDHE-RSA-AES128-GCM-SHA256 ECDHE-ECDSA-AES256-GCM-SHA384 ECDHE-RSA-AES256-GCM-SHA384 ECDHE-ECDSA-WITH-CHACHA20-POLY1305 ECDHE-RSA-WITH-CHACHA20-POLY1305 ECDHE-ECDSA-AES128-CBC-SHA ECDHE-RSA-AES256-CBC-SHA ECDHE-RSA-AES128-CBC-SHA ECDHE-ECDSA-AES256-CBC-SHA RSA-AES128-CBC-SHA RSA-AES256-CBC-SHA RSA-3DES-EDE-CBC-SHA
     {{/if}}

--- a/src/templates/partials/caddy.hbs
+++ b/src/templates/partials/caddy.hbs
@@ -15,7 +15,7 @@ tls {
     ciphers {{{join output.ciphers " "}}}
     {{ else }}
     protocols tls1.0 tls1.1 tls1.2{{#if (includes "TLSv1.3" output.protocols)}} tls1.3{{/if}}
-    # NOTE: Ciphers for old Caddy v1.x are based on recommendations v5.2 and not updated to accomodate newer changes.
+    # NOTE: Ciphers for old Caddy v1.x are based on recommendations v5.2 and not updated anymore:
     ciphers ECDHE-ECDSA-AES128-GCM-SHA256 ECDHE-RSA-AES128-GCM-SHA256 ECDHE-ECDSA-AES256-GCM-SHA384 ECDHE-RSA-AES256-GCM-SHA384 ECDHE-ECDSA-WITH-CHACHA20-POLY1305 ECDHE-RSA-WITH-CHACHA20-POLY1305 ECDHE-ECDSA-AES128-CBC-SHA ECDHE-RSA-AES256-CBC-SHA ECDHE-RSA-AES128-CBC-SHA ECDHE-ECDSA-AES256-CBC-SHA RSA-AES128-CBC-SHA RSA-AES256-CBC-SHA RSA-3DES-EDE-CBC-SHA
     {{/if}}
 }
@@ -24,11 +24,11 @@ tls {
 
 # Due to a lack of DHE support, you -must- use an ECDSA cert to support IE 11 on Windows 7
 tls {
-    protocols tls1.2 tls1.3
+    protocols tls1.2{{#if (includes "TLSv1.3" output.protocols)}} tls1.3{{/if}}
     {{#if (minver "2.0.0" form.serverVersion)}}
     ciphers {{{join output.ciphers " "}}}
     {{ else }}
-    # NOTE: Ciphers for old Caddy v1.x are based on recommendations v5.2 and not updated to accomodate newer changes.
+    # NOTE: Ciphers for old Caddy v1.x are based on recommendations v5.2 and not updated anymore:
     ciphers ECDHE-ECDSA-AES128-GCM-SHA256 ECDHE-RSA-AES128-GCM-SHA256 ECDHE-ECDSA-AES256-GCM-SHA384 ECDHE-RSA-AES256-GCM-SHA384 ECDHE-ECDSA-WITH-CHACHA20-POLY1305 ECDHE-RSA-WITH-CHACHA20-POLY1305
     {{/if}}
 }

--- a/src/templates/partials/caddy.hbs
+++ b/src/templates/partials/caddy.hbs
@@ -10,10 +10,11 @@ example.com
 {{#if (includes "old" form.config)}}
 
 tls {
-    protocols tls1.0 tls1.3
     {{#if (minver "2.0.0" form.serverVersion)}}
+    protocols tls1.2 tls1.3
     ciphers {{{join output.ciphers " "}}}
     {{ else }}
+    protocols tls1.0 tls1.1 tls1.2 tls1.3
     # NOTE: Ciphers for old Caddy v1.x are based on recommendations v5.2 and not updated to accomodate newer changes.
     ciphers ECDHE-ECDSA-AES128-GCM-SHA256 ECDHE-RSA-AES128-GCM-SHA256 ECDHE-ECDSA-AES256-GCM-SHA384 ECDHE-RSA-AES256-GCM-SHA384 ECDHE-ECDSA-WITH-CHACHA20-POLY1305 ECDHE-RSA-WITH-CHACHA20-POLY1305 ECDHE-ECDSA-AES128-CBC-SHA ECDHE-RSA-AES256-CBC-SHA ECDHE-RSA-AES128-CBC-SHA ECDHE-ECDSA-AES256-CBC-SHA RSA-AES128-CBC-SHA RSA-AES256-CBC-SHA RSA-3DES-EDE-CBC-SHA
     {{/if}}

--- a/src/templates/partials/caddy.hbs
+++ b/src/templates/partials/caddy.hbs
@@ -6,7 +6,7 @@
 
 # replace example.com with your domain name
 example.com
-{{! This is a big of a kludge due to Caddy restrictions on TLS versions and cipher suites }}
+{{! There are hard-coded configs for Caddy v1.x separate from uptodate configs for Caddy v2.x due to restrictions on TLS versions and cipher suites }}
 {{#if (includes "old" form.config)}}
 
 tls {
@@ -14,6 +14,7 @@ tls {
     {{#if (minver "2.0.0" form.serverVersion)}}
     ciphers {{{join output.ciphers " "}}}
     {{ else }}
+    # NOTE: Ciphers for old Caddy v1.x are based on recommendations v5.2 and not updated to accomodate newer changes.
     ciphers ECDHE-ECDSA-AES128-GCM-SHA256 ECDHE-RSA-AES128-GCM-SHA256 ECDHE-ECDSA-AES256-GCM-SHA384 ECDHE-RSA-AES256-GCM-SHA384 ECDHE-ECDSA-WITH-CHACHA20-POLY1305 ECDHE-RSA-WITH-CHACHA20-POLY1305 ECDHE-ECDSA-AES128-CBC-SHA ECDHE-RSA-AES256-CBC-SHA ECDHE-RSA-AES128-CBC-SHA ECDHE-ECDSA-AES256-CBC-SHA RSA-AES128-CBC-SHA RSA-AES256-CBC-SHA RSA-3DES-EDE-CBC-SHA
     {{/if}}
 }
@@ -26,6 +27,7 @@ tls {
     {{#if (minver "2.0.0" form.serverVersion)}}
     ciphers {{{join output.ciphers " "}}}
     {{ else }}
+    # NOTE: Ciphers for old Caddy v1.x are based on recommendations v5.2 and not updated to accomodate newer changes.
     ciphers ECDHE-ECDSA-AES128-GCM-SHA256 ECDHE-RSA-AES128-GCM-SHA256 ECDHE-ECDSA-AES256-GCM-SHA384 ECDHE-RSA-AES256-GCM-SHA384 ECDHE-ECDSA-WITH-CHACHA20-POLY1305 ECDHE-RSA-WITH-CHACHA20-POLY1305
     {{/if}}
 }


### PR DESCRIPTION
some more `output.*` conditional logic to caddy v1 & v2 configs
- v2 always supports tls13
- v2 never supports tls10-tls11
- v1 can support tls10-tls11
- v1 can support tls13 (starting v0.11.5)

most of the config was hard-coded for v1.x, so this adds some flexibility for v2.x changes