### PR TITLE
Join output protocols

### DIFF
--- a/src/templates/partials/mysql.hbs
+++ b/src/templates/partials/mysql.hbs
@@ -7,4 +7,4 @@ ssl-key = /path/to/private_key
 {{#if output.ciphers.length}}
 ssl-cipher = {{{join output.ciphers ":"}}}
 {{/if}}
-tls_version = {{#each output.protocols}}{{this}}{{#unless @last}},{{/unless}}{{/each}}
+tls_version = {{join output.protocols ","}}

--- a/src/templates/partials/nginx.hbs
+++ b/src/templates/partials/nginx.hbs
@@ -42,7 +42,7 @@ server {
 
 {{/if}}
     # {{form.config}} configuration
-    ssl_protocols{{#each output.protocols}} {{this}}{{/each}};
+    ssl_protocols {{join output.protocols " "}};
 {{#if output.ciphers.length}}
     ssl_ciphers {{{join output.ciphers ":"}}};
 {{/if}}

--- a/src/templates/partials/proftpd.hbs
+++ b/src/templates/partials/proftpd.hbs
@@ -19,7 +19,7 @@ TLSDHParamFile                /path/to/dhparam
 {{/if}}
 
 # {{form.config}} configuration
-TLSProtocol                  {{#each output.protocols}} {{this}}{{/each}}
+TLSProtocol                   {{join output.protocols " "}}
 {{#if output.ciphers.length}}
 TLSCipherSuite                {{{join output.ciphers ":"}}}
 {{/if}}

--- a/src/templates/partials/redis.hbs
+++ b/src/templates/partials/redis.hbs
@@ -19,7 +19,7 @@ tls-dh-params-file /path/to/dhparam
 {{/if}}
 
 # {{form.config}} configuration
-tls-protocols "{{#each output.protocols}}{{this}}{{#unless @last}} {{/unless}}{{/each}}"
+tls-protocols "{{join output.protocols " "}}"
 {{#if output.ciphers.length}}
 tls-ciphers {{{join output.ciphers ":"}}}
 {{/if}}

--- a/src/templates/partials/tomcat.hbs
+++ b/src/templates/partials/tomcat.hbs
@@ -17,7 +17,7 @@
 {{/if}}
         disableSessionTickets="true"
         honorCipherOrder="{{#if output.serverPreferredOrder}}true{{else}}false{{/if}}"
-        protocols="{{#each output.protocols}}{{this}}{{#unless @last}}, {{/unless}}{{/each}}">
+        protocols="{{join output.protocols ","}}">
 
         <Certificate
             certificateFile="/path/to/signed_certificate"

--- a/src/templates/partials/tomcat.hbs
+++ b/src/templates/partials/tomcat.hbs
@@ -17,7 +17,7 @@
 {{/if}}
         disableSessionTickets="true"
         honorCipherOrder="{{#if output.serverPreferredOrder}}true{{else}}false{{/if}}"
-        protocols="{{join output.protocols ","}}">
+        protocols="{{join output.protocols ", "}}">
 
         <Certificate
             certificateFile="/path/to/signed_certificate"


### PR DESCRIPTION
simplifying various expressions to achieve the same, now join() helper

- what happens on empty array? should not happen? ~~(render nosupport.hbs instead?) should test and avoid setting when empty?~~ (no change from now)
- ~~what happens on single element? renders as intended w/o trailing separator etc.?~~
- is just a helper for Array.prototype.join() so usual applies: nullish/undef return empty string, single element returns with no separator, default separator is comma, separator can be any length etc. …
- _precedent: dovecot (no test etc., just expecting one or more members)_

~~OQ: where comma separated, "," vs ", " space plays any role?~~ updated tomcat to original spacing