### PR TITLE
Fix Jetty TLSv1.3 IncludeCipherSuites

### DIFF
--- a/src/js/configs.js
+++ b/src/js/configs.js
@@ -88,7 +88,7 @@ module.exports = {
   jetty: {
     cipherFormat: 'iana',
     highlighter: 'xml',
-    latestVersion: '9.4.28',
+    latestVersion: '12.0.5',
     name: 'Jetty',
     supportsHsts: false,
     supportsOcspStapling: false,

--- a/src/templates/partials/jetty.hbs
+++ b/src/templates/partials/jetty.hbs
@@ -18,9 +18,11 @@
 {{#if output.ciphers.length}}
   <Set name="IncludeCipherSuites">
     <Array type="String">
-  {{#each output.cipherSuites}}{{!-- if IncludeCipherSuites is set and TLSv1.3 used, the defaults need to be included --}}
+  {{#if (includes "TLSv1.3" output.protocols)}}{{!-- if IncludeCipherSuites is set and TLSv1.3 used, the defaults need to be included --}}
+    {{#each output.cipherSuites}}
       <Item>{{this}}</Item>
-  {{/each}}
+    {{/each}}
+  {{/if}}
   {{#each output.ciphers}}
       <Item>{{this}}</Item>
   {{/each}}

--- a/src/templates/partials/jetty.hbs
+++ b/src/templates/partials/jetty.hbs
@@ -18,15 +18,10 @@
 {{#if output.ciphers.length}}
   <Set name="IncludeCipherSuites">
     <Array type="String">
-  {{#each output.ciphers}}
+  {{#each output.cipherSuites}}{{!-- if IncludeCipherSuites is set and TLSv1.3 used, the defaults need to be included --}}
       <Item>{{this}}</Item>
   {{/each}}
-    </Array>
-  </Set>
-{{else}}{{!-- IncludeCipherSuites can't be empty, output defaults for TLSv1.3 --}}
-  <Set name="IncludeCipherSuites">
-    <Array type="String">
-  {{#each output.cipherSuites}}
+  {{#each output.ciphers}}
       <Item>{{this}}</Item>
   {{/each}}
     </Array>

--- a/src/templates/partials/jetty.hbs
+++ b/src/templates/partials/jetty.hbs
@@ -23,6 +23,14 @@
   {{/each}}
     </Array>
   </Set>
+{{else}}{{!-- IncludeCipherSuites can't be empty, output defaults for TLSv1.3 --}}
+  <Set name="IncludeCipherSuites">
+    <Array type="String">
+  {{#each output.cipherSuites}}
+      <Item>{{this}}</Item>
+  {{/each}}
+    </Array>
+  </Set>
 {{/if}}
 
   <Set name="useCipherSuitesOrder">

--- a/src/templates/partials/jetty.hbs
+++ b/src/templates/partials/jetty.hbs
@@ -6,7 +6,7 @@
     <Property name="jetty.sslContext.keyStorePath" default="/path/to/key_store" />
   </Set>
 
-  <!-- TLS 1.3 requires Java 11 or higher -->
+  {{#if (includes "TLSv1.3" output.protocols)}}<!-- TLSv1.3 requires Java 11 or higher -->{{/if}}
   <Set name="IncludeProtocols">
     <Array type="String">
       {{#each output.protocols}}

--- a/src/templates/partials/jetty.hbs
+++ b/src/templates/partials/jetty.hbs
@@ -18,7 +18,7 @@
 {{#if output.ciphers.length}}
   <Set name="IncludeCipherSuites">
     <Array type="String">
-  {{#if (includes "TLSv1.3" output.protocols)}}{{!-- if IncludeCipherSuites is set and TLSv1.3 used, the defaults need to be included --}}
+  {{#if (includes "TLSv1.3" output.protocols)}}
     {{#each output.cipherSuites}}
       <Item>{{this}}</Item>
     {{/each}}


### PR DESCRIPTION
when intermediate & old specify ciphers also add the tls13 default suites if tls13 allowed