### PR TITLE
Fix Tomcat TLSv1.3 when TLSv1.2 ciphers configured

### DIFF
--- a/src/js/configs.js
+++ b/src/js/configs.js
@@ -187,7 +187,7 @@ module.exports = {
   },
 tomcat: {
     highlighter: 'xml',
-    latestVersion: '9.0.30',
+    latestVersion: '9.0.85',
     name: 'Tomcat',
     supportsHsts: true,
     supportsOcspStapling: false,

--- a/src/js/configs.js
+++ b/src/js/configs.js
@@ -99,7 +99,7 @@ module.exports = {
     highlighter: 'nginx',
     latestVersion: '1.4.67',
     name: 'lighttpd',
-    tls13: '1.4.48'
+    tls13: '1.4.48',
   },
   mysql: {
     highlighter: 'ini',
@@ -125,9 +125,8 @@ module.exports = {
     highlighter: 'apache',
     latestVersion: '12.2.1',
     name: 'Oracle HTTP',
-    supportsHsts: true,
-    supportsOcspStapling: false,  // TODO: fix this, but Oracle's documentation is terrible
-    tls13: noSupportedVersion,
+    supportsOcspStapling: false,  // TODO: needs updating; docs only available to customers:/
+    tls13: noSupportedVersion,    // TODO: needs updating; docs only available to customers:/
   },
   postfix: {
     highlighter: 'nginx',
@@ -153,7 +152,6 @@ module.exports = {
     name: 'ProFTPD',
     showSupports: false,
     supportsHsts: false,
-    supportsOcspStapling: true,
     tls13: '1.3.7',
   },
   redis: {
@@ -164,7 +162,6 @@ module.exports = {
     supportsHsts: false,
     supportsOcspStapling: false,
     tls13: '6.0',
-    usesOpenssl: true,
   },
   squid: {
     highlighter: 'nginx',  // TODO: find better
@@ -179,17 +176,14 @@ module.exports = {
     highlighter: 'ini',
     latestVersion: '5.71',
     name: 'stunnel',
-    showSupports: false,
     supportsHsts: false,
     supportsOcspStapling: false,
     tls13: '5.50',
-    usesOpenssl: true,
   },
-tomcat: {
+  tomcat: {
     highlighter: 'xml',
     latestVersion: '9.0.96',
     name: 'Tomcat',
-    supportsHsts: true,
     supportsOcspStapling: false,
     tls13: '8.0.0',
     usesOpenssl: false,
@@ -199,7 +193,6 @@ tomcat: {
     highlighter: 'ini',
     latestVersion: '2.1.2',
     name: 'Traefik',
-    supportsHsts: true,
     supportsOcspStapling: false,  // https://github.com/containous/traefik/issues/212
     tls13: '2.0.0',
     usesOpenssl: false,

--- a/src/js/configs.js
+++ b/src/js/configs.js
@@ -187,7 +187,7 @@ module.exports = {
   },
 tomcat: {
     highlighter: 'xml',
-    latestVersion: '9.0.85',
+    latestVersion: '9.0.96',
     name: 'Tomcat',
     supportsHsts: true,
     supportsOcspStapling: false,

--- a/src/templates/partials/tomcat.hbs
+++ b/src/templates/partials/tomcat.hbs
@@ -10,14 +10,14 @@
     port="443"
     SSLEnabled="true">
 
-    <!-- TLS 1.3 requires Java 11 or higher -->
+    {{#if (includes "TLSv1.3" output.protocols)}}<!-- TLSv1.3 requires Java 11 or higher -->{{/if}}
     <SSLHostConfig
 {{#if output.ciphers.length}}
-        ciphers="{{{join output.ciphers ":"}}}"
+        ciphers="{{#if (includes "TLSv1.3" output.protocols)}}{{{join output.cipherSuites ":"}}}:{{/if}}{{{join output.ciphers ":"}}}"
 {{/if}}
         disableSessionTickets="true"
         honorCipherOrder="{{#if output.serverPreferredOrder}}true{{else}}false{{/if}}"
-        protocols="{{join output.protocols ", "}}">
+        protocols="{{join output.protocols ","}}">
 
         <Certificate
             certificateFile="/path/to/signed_certificate"


### PR DESCRIPTION
OpenSSL vs JSSE issue?
https://stackoverflow.com/a/68818408

(no implementation set for Connector, APR due to OpenSSL naming implied? JSSE will accept that instead of IANA thou — so APR won't configure TLSv1.3 at all and apply defaults, while JSSE will adhere to the cipher list for all protocols, needing the TLSv1.3 defaults explicitly enumerated in the allowed ciphers?)

TODO: mention APR vs. JSSE implementation differences somehow?

OQ: hardcoded delimiter… if tls13 ➡️ ciperSuites won't be empty, no addtl test for trailing ":" needed?